### PR TITLE
Add design config for Haitian theme

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -13,7 +13,9 @@ function App() {
 
   return (
     <div ref={container} className="opacity-0">
-      <h1 className="text-4xl font-bold text-center">Bienvenue au Restaurant</h1>
+      <h1 className="text-4xl font-bold text-center text-[color:var(--color-primary)]">
+        Bienvenue au Restaurant
+      </h1>
     </div>
   );
 }

--- a/config/assets.ts
+++ b/config/assets.ts
@@ -1,0 +1,4 @@
+export const assets = {
+  logo: '/assets/react.svg',
+};
+export default assets;

--- a/config/colors.ts
+++ b/config/colors.ts
@@ -1,0 +1,8 @@
+export const colors = {
+  primary: '#0052A5', // Haitian blue
+  secondary: '#D21034', // Haitian red
+  accent: '#FDB813', // subtle yellow accent
+  background: '#ffffff',
+  text: '#213547',
+};
+export default colors;

--- a/config/fonts.ts
+++ b/config/fonts.ts
@@ -1,0 +1,5 @@
+export const fonts = {
+  primary: `'Lato', sans-serif`,
+  heading: `'Playfair Display', serif`,
+};
+export default fonts;

--- a/config/index.ts
+++ b/config/index.ts
@@ -1,0 +1,3 @@
+export * from './colors';
+export * from './fonts';
+export * from './assets';

--- a/index.css
+++ b/index.css
@@ -1,10 +1,19 @@
+@import url('https://fonts.googleapis.com/css2?family=Lato:wght@400;700&family=Playfair+Display:wght@400;700&display=swap');
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
 
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  --font-primary: 'Lato', sans-serif;
+  --font-heading: 'Playfair Display', serif;
+  --color-primary: #0052A5;
+  --color-secondary: #D21034;
+  --color-accent: #FDB813;
+  --color-background: #ffffff;
+  --color-text: #213547;
+
+  font-family: var(--font-primary);
   line-height: 1.5;
   font-weight: 400;
 
@@ -20,11 +29,11 @@
 
 a {
   font-weight: 500;
-  color: #646cff;
+  color: var(--color-primary);
   text-decoration: inherit;
 }
 a:hover {
-  color: #535bf2;
+  color: var(--color-secondary);
 }
 
 body {
@@ -36,6 +45,7 @@ body {
 }
 
 h1 {
+  font-family: var(--font-heading);
   font-size: 3.2em;
   line-height: 1.1;
 }
@@ -52,7 +62,7 @@ button {
   transition: border-color 0.25s;
 }
 button:hover {
-  border-color: #646cff;
+  border-color: var(--color-primary);
 }
 button:focus,
 button:focus-visible {
@@ -61,11 +71,11 @@ button:focus-visible {
 
 @media (prefers-color-scheme: light) {
   :root {
-    color: #213547;
-    background-color: #ffffff;
+    color: var(--color-text);
+    background-color: var(--color-background);
   }
   a:hover {
-    color: #747bff;
+    color: var(--color-primary);
   }
   button {
     background-color: #f9f9f9;


### PR DESCRIPTION
## Summary
- create a `config` folder for fonts, colors and asset paths
- theme `index.css` with Haitian-inspired colors and fonts
- use new colors in the example heading

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684b05678f308320b311e5eef98c181d