### PR TITLE
Add delivery logos in mobile navbar buttons

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -207,37 +207,17 @@ export default function Header() {
             href={assets.uberEatsLink}
             target="_blank"
             rel="noopener noreferrer"
-            className="group relative overflow-hidden text-white px-5 py-2 rounded-full font-semibold text-sm shadow-lg hover:shadow-xl transform hover:scale-105 transition-all duration-300 focus:outline-none focus:ring-4"
-            style={{
-              background: 'linear-gradient(135deg, #8B4513, #A0522D)',
-            }}
+            className="p-2 focus:outline-none"
           >
-            <span className="relative z-10 flex items-center space-x-2">
-              <img src={assets.uberEatsLogo} alt="Uber Eats" className="w-4 h-4" />
-              <span>Uber Eats</span>
-            </span>
-            <div
-              className="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-300"
-              style={{ background: 'linear-gradient(135deg, #A0522D, #8B4513)' }}
-            ></div>
+            <img src={assets.uberEatsLogo} alt="Uber Eats" className="w-6 h-6" />
           </a>
           <a
             href={assets.doorDashLink}
             target="_blank"
             rel="noopener noreferrer"
-            className="group relative overflow-hidden text-white px-5 py-2 rounded-full font-semibold text-sm shadow-lg hover:shadow-xl transform hover:scale-105 transition-all duration-300 focus:outline-none focus:ring-4"
-            style={{
-              background: 'linear-gradient(135deg, #8B4513, #A0522D)',
-            }}
+            className="p-2 focus:outline-none"
           >
-            <span className="relative z-10 flex items-center space-x-2">
-              <img src={assets.doorDashLogo} alt="DoorDash" className="w-4 h-4" />
-              <span>DoorDash</span>
-            </span>
-            <div
-              className="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-300"
-              style={{ background: 'linear-gradient(135deg, #A0522D, #8B4513)' }}
-            ></div>
+            <img src={assets.doorDashLogo} alt="DoorDash" className="w-6 h-6" />
           </a>
         </div>
 
@@ -302,14 +282,9 @@ export default function Header() {
                   href={assets.uberEatsLink}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="group relative overflow-hidden text-white px-6 py-2 rounded-full font-semibold text-sm shadow-lg hover:shadow-xl transform hover:scale-105 transition-all duration-300 focus:outline-none focus:ring-4"
-                  style={{ background: 'linear-gradient(135deg, #8B4513, #A0522D)' }}
+                  className="p-2 focus:outline-none"
                 >
-                  <span className="relative z-10">Uber Eats</span>
-                  <div
-                    className="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-300"
-                    style={{ background: 'linear-gradient(135deg, #A0522D, #8B4513)' }}
-                  ></div>
+                  <img src={assets.uberEatsLogo} alt="Uber Eats" className="w-6 h-6" />
                 </a>
               </li>
               <li>
@@ -317,14 +292,9 @@ export default function Header() {
                   href={assets.doorDashLink}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="group relative overflow-hidden text-white px-6 py-2 rounded-full font-semibold text-sm shadow-lg hover:shadow-xl transform hover:scale-105 transition-all duration-300 focus:outline-none focus:ring-4"
-                  style={{ background: 'linear-gradient(135deg, #8B4513, #A0522D)' }}
+                  className="p-2 focus:outline-none"
                 >
-                  <span className="relative z-10">DoorDash</span>
-                  <div
-                    className="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-300"
-                    style={{ background: 'linear-gradient(135deg, #A0522D, #8B4513)' }}
-                  ></div>
+                  <img src={assets.doorDashLogo} alt="DoorDash" className="w-6 h-6" />
                 </a>
               </li>
             </ul>


### PR DESCRIPTION
## Summary
- show UberEats and DoorDash logos on the mobile menu buttons
- make the delivery buttons icon-only

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684b51084a808320928a42393e984941