### PR TITLE
Make griot dish appear last

### DIFF
--- a/src/config/assets.ts
+++ b/src/config/assets.ts
@@ -13,12 +13,12 @@ export const assets = {
     fritaille: '/images/fritaille.avif',
     goat: '/images/goat.avif',
     goatTassot: '/images/goat_tassot.avif',
-    griotPorc: '/images/griot_porc.avif',
     halfChicken: '/images/half_chicken.avif',
     salad: '/images/salad_of_the_moment.avif',
     thomsonFish: '/images/thomson_fish.avif',
     tilapia: '/images/tilapia.avif',
-    makayabus: '/images/two_Makayabus.avif'
+    makayabus: '/images/two_Makayabus.avif',
+    griotPorc: '/images/griot_porc.avif'
   }
 };
 export default assets;


### PR DESCRIPTION
## Summary
- reorder assets list so `griotPorc` comes after the other dishes

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684b55ae3e248320bf1c1c31ae6d64a2